### PR TITLE
Add Reshape decorator for post-decode/pre-encode data transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ✨ add `Reshape` decorator for transforming decoded/encoded shape without changing binary layout. See `Reshape.test.ts` and README for example usage
+
 ## 6.0.1 2025-12-13
 
 A new major version! This is based on published changes from the original upstream project which included a lot of refactoring and cleanup work. (note there is no 6.0.0 due to a mistake in publishing)

--- a/README.md
+++ b/README.md
@@ -295,6 +295,63 @@ const c_str = new Inject(
 
 See `Inject.test.ts` file.
 
+## Reshape
+
+Transform the decoded/encoded shape of a struct (or any buffer-like) without touching its binary layout. Give it a `decode` function to map the raw decoded value to whatever shape you want, and an `encode` function to map it back.
+
+```ts
+import { StructBuffer, Reshape, uint8_t } from "@nmann/struct-buffer";
+
+const raw = new StructBuffer({
+  x_lo: uint8_t,
+  x_hi: uint8_t,
+});
+
+const reshaped = new Reshape(raw, {
+  decode: (data) => ({ x: data.x_lo | (data.x_hi << 8) }),
+  encode: (data: { x: number }) => ({
+    x_lo: data.x & 0xff,
+    x_hi: (data.x >> 8) & 0xff,
+  }),
+});
+
+// encode
+const view = reshaped.encode({ x: 0x0102 });
+// view => <02 01>
+
+// decode
+const obj = reshaped.decode(view);
+// obj => { x: 0x0102 }
+```
+
+It can also be nested inside another struct as a field:
+
+```ts
+const inner = new StructBuffer({
+  lo: uint8_t,
+  hi: uint8_t,
+});
+
+const reshaped = new Reshape(inner, {
+  decode: (data) => data.lo | (data.hi << 8),
+  encode: (val: number) => ({
+    lo: val & 0xff,
+    hi: (val >> 8) & 0xff,
+  }),
+});
+
+const outer = new StructBuffer({
+  id: uint8_t,
+  value: reshaped,
+});
+
+// encode
+outer.encode({ id: 42, value: 0x0304 });
+// => <2a 04 03>
+```
+
+See `Reshape.test.ts` file.
+
 ## [pack and unpack](https://docs.python.org/3/library/struct.html)
 
 ```ts

--- a/src/decorator/Reshape.ts
+++ b/src/decorator/Reshape.ts
@@ -33,6 +33,6 @@ export class Reshape<SrcD, SrcE, D, E> extends BufferLikeDecorator<D, E> {
 
   override encode(obj: E, options?: IEncodeOptions): DataView {
     const raw = this.transforms.encode(obj);
-    return this.src.encode(raw, options) as DataView;
+    return this.src.encode(raw as unknown as E, options) as DataView;
   }
 }

--- a/src/decorator/Reshape.ts
+++ b/src/decorator/Reshape.ts
@@ -1,0 +1,38 @@
+import {
+  LikeBuffer_t,
+  IDecodeOptions,
+  IEncodeOptions,
+  IBufferLike,
+} from "../interfaces.js";
+import BufferLikeDecorator from "./BufferLikeDecorator.js";
+
+export interface ReshapeTransforms<SrcD, SrcE, D, E> {
+  decode: (raw: SrcD) => D;
+  encode: (shaped: E) => SrcE;
+}
+
+export class Reshape<SrcD, SrcE, D, E> extends BufferLikeDecorator<D, E> {
+  constructor(
+    src: IBufferLike<SrcD, SrcE>,
+    private readonly transforms: ReshapeTransforms<SrcD, SrcE, D, E>,
+  ) {
+    super(src as unknown as IBufferLike<D, E>);
+  }
+
+  override intAccess(i: number) {
+    const next = super.intAccess(i);
+    (next as any).transforms = this.transforms;
+    (next as any).src = this.src[i];
+    return next;
+  }
+
+  override decode(view: LikeBuffer_t, options?: IDecodeOptions): D {
+    const raw = this.src.decode(view, options) as unknown as SrcD;
+    return this.transforms.decode(raw);
+  }
+
+  override encode(obj: E, options?: IEncodeOptions): DataView {
+    const raw = this.transforms.encode(obj);
+    return this.src.encode(raw, options) as DataView;
+  }
+}

--- a/src/decorator/index.ts
+++ b/src/decorator/index.ts
@@ -1,2 +1,3 @@
 export * from "./LittleEndian.js";
 export * from "./RelativeOffset.js";
+export * from "./Reshape.js";

--- a/test/decorator/Reshape.test.ts
+++ b/test/decorator/Reshape.test.ts
@@ -1,0 +1,99 @@
+import test from "ava";
+import {
+  StructBuffer,
+  uint8_t,
+  uint16_t,
+  sview,
+  Reshape,
+} from "../../src/index.js";
+
+test("reshape struct - combine low and high bytes", (t) => {
+  const raw = new StructBuffer({
+    x_lo: uint8_t,
+    x_hi: uint8_t,
+  });
+
+  const reshaped = new Reshape(raw, {
+    decode: (data) => ({ x: data.x_lo | (data.x_hi << 8) }),
+    encode: (data: { x: number }) => ({
+      x_lo: data.x & 0xff,
+      x_hi: (data.x >> 8) & 0xff,
+    }),
+  });
+
+  const view = reshaped.encode({ x: 0x0102 });
+  t.is(sview(view), "02 01");
+
+  const obj = reshaped.decode(view);
+  t.is(obj.x, 0x0102);
+});
+
+test("reshape struct - rename fields", (t) => {
+  const raw = new StructBuffer({
+    a: uint16_t,
+    b: uint16_t,
+  });
+
+  const reshaped = new Reshape(raw, {
+    decode: (data) => ({ width: data.a, height: data.b }),
+    encode: (data: { width: number; height: number }) => ({
+      a: data.width,
+      b: data.height,
+    }),
+  });
+
+  const view = reshaped.encode({ width: 100, height: 200 });
+  const obj = reshaped.decode(view);
+  t.is(obj.width, 100);
+  t.is(obj.height, 200);
+});
+
+test("reshape used inside another struct", (t) => {
+  const inner = new StructBuffer({
+    lo: uint8_t,
+    hi: uint8_t,
+  });
+
+  const reshaped = new Reshape(inner, {
+    decode: (data) => data.lo | (data.hi << 8),
+    encode: (val: number) => ({
+      lo: val & 0xff,
+      hi: (val >> 8) & 0xff,
+    }),
+  });
+
+  const outer = new StructBuffer({
+    id: uint8_t,
+    value: reshaped,
+  });
+
+  const view = outer.encode({ id: 42, value: 0x0304 });
+  t.is(sview(view), "2a 04 03");
+
+  const obj = outer.decode(view);
+  t.is(obj.id, 42);
+  t.is(obj.value, 0x0304);
+});
+
+test("reshape roundtrip preserves data", (t) => {
+  const raw = new StructBuffer({
+    r: uint8_t,
+    g: uint8_t,
+    b: uint8_t,
+  });
+
+  const reshaped = new Reshape(raw, {
+    decode: (data) => `#${data.r.toString(16).padStart(2, "0")}${data.g.toString(16).padStart(2, "0")}${data.b.toString(16).padStart(2, "0")}`,
+    encode: (hex: string) => ({
+      r: parseInt(hex.slice(1, 3), 16),
+      g: parseInt(hex.slice(3, 5), 16),
+      b: parseInt(hex.slice(5, 7), 16),
+    }),
+  });
+
+  const view = reshaped.encode("#ff8040");
+  t.is(sview(view), "ff 80 40");
+
+  const decoded = reshaped.decode(view);
+  t.is(decoded, "#ff8040");
+});


### PR DESCRIPTION
Enables more intuitive shaping of data from binary layouts into any arbitrary javascript representation. Type safety is maintained across the transformation as with anything else in the package. 